### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,15 +1,15 @@
-SimpleSerial  KEYWORD1
+SimpleSerial	KEYWORD1
 
-available     KEYWORD2
-read          KEYWORD2
-bytes2Float   KEYWORD2
-float2Bytes   KEYWORD2
-bytes2Int     KEYWORD2
-int2Bytes     KEYWORD2
-send          KEYWORD2
-sendFloat     KEYWORD2
-sendInt       KEYWORD2
-readLoop      KEYWORD2
-sendLoop      KEYWORD2
+available	KEYWORD2
+read	KEYWORD2
+bytes2Float	KEYWORD2
+float2Bytes	KEYWORD2
+bytes2Int	KEYWORD2
+int2Bytes	KEYWORD2
+send	KEYWORD2
+sendFloat	KEYWORD2
+sendInt	KEYWORD2
+readLoop	KEYWORD2
+sendLoop	KEYWORD2
 
-MAX_LEN_PYLD  KEYWORD3
+MAX_LEN_PYLD	KEYWORD3


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords